### PR TITLE
Update gulp coffeescript instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ IE 11  | Firefox 36 | Chrome 41 | Safari 8
 Pull requests are welcome! Create another file in `src/animations`
 and load it in `src/loader.scss`.
 
-In a separate tab run `gulp --require coffee-script`. Open `demo/demo.html`
+In a separate tab run `gulp --require coffee-script/register`. Open `demo/demo.html`
 in a browser to see your animation running.
 
 ### Further research


### PR DESCRIPTION
The current instructions for running the gulp build don't work.

To register the coffeescript compiler in node, you need to require `coffee-script/register`, so in order to get gulp to run correctly, I had to change `gulp --require coffee-script` to `gulp --require coffee-script/register`.