### PR TITLE
Use negative animation delays to keep iOS in sync

### DIFF
--- a/src/_functions.scss
+++ b/src/_functions.scss
@@ -1,0 +1,3 @@
+@function delay($interval, $count, $index) {
+  @return ($index * $interval) - ($interval * $count);
+}

--- a/src/animations/ball-beat.scss
+++ b/src/animations/ball-beat.scss
@@ -22,7 +22,7 @@
     animation: ball-beat 0.7s 0s infinite linear;
 
     &:nth-child(2n-1) {
-      animation-delay: 0.35s !important;
+      animation-delay: -0.35s !important;
     }
   }
 }

--- a/src/animations/ball-pulse-sync.scss
+++ b/src/animations/ball-pulse-sync.scss
@@ -1,5 +1,6 @@
 @import '../variables';
 @import '../mixins';
+@import '../functions';
 
 $amount: 10px;
 
@@ -18,7 +19,7 @@ $amount: 10px;
 @mixin ball-pulse-sync($n:3, $start:0) {
   @for $i from $start through $n {
     > div:nth-child(#{$i}) {
-      animation: ball-pulse-sync 0.6s ($i * 0.07s) infinite ease-in-out;
+      animation: ball-pulse-sync 0.6s delay(0.07s, $n, $i) infinite ease-in-out;
     }
   }
 }

--- a/src/animations/ball-pulse.scss
+++ b/src/animations/ball-pulse.scss
@@ -1,5 +1,6 @@
 @import '../variables';
 @import '../mixins';
+@import '../functions';
 
 @keyframes scale {
   0% {
@@ -20,7 +21,7 @@
 @mixin ball-pulse($n:3, $start:0) {
   @for $i from $start through $n {
     > div:nth-child(#{$i}) {
-      animation: scale 0.75s ($i * 0.12s) infinite cubic-bezier(.2,.68,.18,1.08);
+      animation: scale 0.75s delay(0.12s, $n, $i) infinite cubic-bezier(.2,.68,.18,1.08);
     }
   }
 }

--- a/src/animations/ball-scale-multiple.scss
+++ b/src/animations/ball-scale-multiple.scss
@@ -1,5 +1,6 @@
 @import '../variables';
 @import '../mixins';
+@import '../functions';
 
 $size: 60px;
 
@@ -20,7 +21,7 @@ $size: 60px;
 @mixin ball-scale-multiple ($n:3, $start:0) {
   @for $i from 2 through $n {
     > div:nth-child(#{$i}) {
-      animation-delay: (($i - 1) * 0.2) + s;
+      animation-delay: delay(0.2s, $n, $i - 1);
     }
   }
 }

--- a/src/animations/ball-scale-ripple-multiple.scss
+++ b/src/animations/ball-scale-ripple-multiple.scss
@@ -1,5 +1,6 @@
 @import '../variables';
 @import '../mixins';
+@import '../functions';
 
 $size: 50px;
 
@@ -20,7 +21,7 @@ $size: 50px;
 @mixin ball-scale-ripple-multiple ($n:3, $start:0) {
   @for $i from $start through $n {
     > div:nth-child(#{$i}) {
-      animation-delay: (($i - 1) * 0.2) + s;
+      animation-delay: delay(0.2s, $n, $i - 1);
     }
   }
 }

--- a/src/animations/ball-spin-fade-loader.scss
+++ b/src/animations/ball-spin-fade-loader.scss
@@ -1,5 +1,6 @@
 @import '../variables';
 @import '../mixins';
+@import '../functions';
 
 $radius: 25px;
 
@@ -46,7 +47,7 @@ $radius: 25px;
         left: -$quarter;
       }
 
-      animation: ball-spin-fade-loader 1s (($i - 1) * 0.12s) infinite linear;
+      animation: ball-spin-fade-loader 1s delay(0.12s, $n, $i - 1) infinite linear;
     }
   }
 }

--- a/src/animations/line-scale-pulse-out-rapid.scss
+++ b/src/animations/line-scale-pulse-out-rapid.scss
@@ -20,14 +20,14 @@
     @include global-animation();
 
     display: inline-block;
-    animation: line-scale-pulse-out-rapid 0.9s 0s infinite cubic-bezier(.11,.49,.38,.78);
+    animation: line-scale-pulse-out-rapid 0.9s -0.5s infinite cubic-bezier(.11,.49,.38,.78);
 
     &:nth-child(2), &:nth-child(4) {
-      animation-delay: 0.25s !important;
+      animation-delay: -0.25s !important;
     }
 
     &:nth-child(1), &:nth-child(5) {
-      animation-delay: 0.5s !important;
+      animation-delay: 0s !important;
     }
   }
 }

--- a/src/animations/line-scale-pulse-out.scss
+++ b/src/animations/line-scale-pulse-out.scss
@@ -1,5 +1,6 @@
 @import '../variables';
 @import '../mixins';
+@import '../functions';
 
 @keyframes line-scale-pulse-out {
   0% {
@@ -20,14 +21,14 @@
     @include global-animation();
 
     display: inline-block;
-    animation: line-scale-pulse-out 0.9s 0s infinite cubic-bezier(.85,.25,.37,.85);
+    animation: line-scale-pulse-out 0.9s delay(0.2s, 3, 0) infinite cubic-bezier(.85,.25,.37,.85);
 
     &:nth-child(2), &:nth-child(4) {
-      animation-delay: 0.2s !important;
+      animation-delay: delay(0.2s, 3, 1) !important;
     }
 
     &:nth-child(1), &:nth-child(5) {
-      animation-delay: 0.4s !important;
+      animation-delay: delay(0.2s, 3, 2) !important;
     }
 
   }

--- a/src/animations/line-scale.scss
+++ b/src/animations/line-scale.scss
@@ -1,5 +1,6 @@
 @import '../variables';
 @import '../mixins';
+@import '../functions';
 
 @keyframes line-scale {
   0% {
@@ -16,7 +17,7 @@
 @mixin line-scale($n:5) {
   @for $i from 1 through $n {
     > div:nth-child(#{$i}) {
-      animation: line-scale 1s ($i * 0.1s) infinite cubic-bezier(.2,.68,.18,1.08);
+      animation: line-scale 1s delay(0.1s, $n, $i) infinite cubic-bezier(.2,.68,.18,1.08);
     }
   }
 }

--- a/src/animations/line-spin-fade-loader.scss
+++ b/src/animations/line-spin-fade-loader.scss
@@ -1,5 +1,6 @@
 @import '../variables';
 @import '../mixins';
+@import '../functions';
 
 $radius: 20px;
 
@@ -50,7 +51,7 @@ $radius: 20px;
         transform: rotate(45deg);
       }
 
-      animation: line-spin-fade-loader 1.2s ($i * 0.12s) infinite ease-in-out;
+      animation: line-spin-fade-loader 1.2s delay(0.12s, $n, $i) infinite ease-in-out;
     }
   }
 }

--- a/src/animations/pacman.scss
+++ b/src/animations/pacman.scss
@@ -1,5 +1,6 @@
 @import '../variables';
 @import '../mixins';
+@import '../functions';
 
 $size: 25px;
 
@@ -49,7 +50,7 @@ $size: 25px;
 @mixin ball-placement($n:3, $start:0) {
   @for $i from $start through $n {
     > div:nth-child(#{$i + 2}) {
-      animation: pacman-balls 1s ($i * .33s) infinite linear;
+      animation: pacman-balls 1s delay(.33s, $n, $i) infinite linear;
     }
   }
 }


### PR DESCRIPTION
I was using the `ball-pulse-sync` animation in a project of mine, but noticed that the animations always seemed to get out of sync on iPhone on repeated views.

I found this [issue on StackOverflow](http://stackoverflow.com/questions/15868431/keyframe-animations-not-in-sync) which described what I was seeing, and the solution suggested was to use negative animation delays, which worked for me when I hardcoded it into my app.

Since calculating negative delays is so tedious and error-prone, I introduced a `delay` function in a new file called `_functions.scss` and applied it across the board.

If you have any questions, or would like any further changes, please let me know.