### PR TITLE
[Bug Fix?] Removed a red border around the spinning square

### DIFF
--- a/src/animations/square-spin.scss
+++ b/src/animations/square-spin.scss
@@ -24,7 +24,6 @@
     width: 50px;
     height: 50px;
     background: $primary-color;
-    border: 1px solid red;
     animation: square-spin 3s 0s cubic-bezier(.09,.57,.49,.9) infinite;
   }
 }


### PR DESCRIPTION
Non of the other animations have a red border, except for the spinning square. I get the impression that it wasn't intentional, and was put there for debugging purposes.

Either ways, in my application, instead of scratching my head trying to find the correct loader animation, I decided that upon every load, I'll use a different animation entirely. Let's see how it goes.

However, as I was testing, I noticed the square had a red border, and it just seemed unnatural. It also seems hacky to introduce a `.square-spin > div { border: none; }` in my own code.