### PR TITLE
Add `style` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "loaders.css",
   "version": "0.1.1",
   "description": "Loading animations in pure css",
-  "main": "src/loaders.css",
+  "main": "loaders.css",
+  "style": "loaders.css",
   "repository": {
     "type": "git",
     "url": "git@github.com:ConnorAtherton/loaders.css.git"


### PR DESCRIPTION
The [style field](https://github.com/necolas/normalize.css/blob/master/package.json#L5) helps other utilities such as PostCSS locate the entry point for your module, so I can do things like `@import 'loaders.css';` in my own css and PostCSS will pull this module into my build.

The `main` field was pointing to a non-existant file so I've updated that as well.