### PR TITLE
Fixing addDivs function error

### DIFF
--- a/loaders.css.js
+++ b/loaders.css.js
@@ -34,7 +34,7 @@
 
   var addDivs = function(n) {
     var arr = [];
-    for (i = 1; i <= n; i++) {
+    for (var i = 1; i <= n; i++) {
       arr.push('<div></div>');
     }
     return arr;


### PR DESCRIPTION
Creating a local variable 'i' in the for loop as no variable 'i' can be found in certain circumstances.