### PR TITLE
Add let for modern js compliance

### DIFF
--- a/loaders.css.js
+++ b/loaders.css.js
@@ -34,7 +34,7 @@
 
   var addDivs = function(n) {
     var arr = [];
-    for (i = 1; i <= n; i++) {
+    for (let i = 1; i <= n; i++) {
       arr.push('<div></div>');
     }
     return arr;


### PR DESCRIPTION
Without the let on the row 37, angular 8 crashes when use the addDivs method.