### PR TITLE
Replace / as division operation with the new math.div function in sass issue #102

### DIFF
--- a/src/animations/ball-scale-multiple.scss
+++ b/src/animations/ball-scale-multiple.scss
@@ -1,24 +1,25 @@
-@import '../variables';
-@import '../mixins';
-@import '../functions';
+@use "sass:math";
+@import "../variables";
+@import "../mixins";
+@import "../functions";
 
 $size: 60px;
 
 @keyframes ball-scale-multiple {
   0% {
-    transform: scale(0.0);
+    transform: scale(0);
     opacity: 0;
   }
   5% {
     opacity: 1;
   }
   100% {
-    transform: scale(1.0);
+    transform: scale(1);
     opacity: 0;
   }
 }
 
-@mixin ball-scale-multiple ($n: 3, $start: 2) {
+@mixin ball-scale-multiple($n: 3, $start: 2) {
   @for $i from $start through $n {
     > div:nth-child(#{$i}) {
       animation-delay: delay(0.2s, $n, $i - 1);
@@ -30,7 +31,7 @@ $size: 60px;
   @include ball-scale-multiple();
 
   position: relative;
-  transform: translateY(-$size / 2);
+  transform: translateY(math.div(-$size, 2));
 
   > div {
     @include balls();

--- a/src/animations/pacman.scss
+++ b/src/animations/pacman.scss
@@ -1,41 +1,42 @@
-@import '../variables';
-@import '../mixins';
-@import '../functions';
+@use "sass:math";
+@import "../variables";
+@import "../mixins";
+@import "../functions";
 
 $size: 25px;
 
-@keyframes rotate_pacman_half_up  {
-    0% {
-         transform:rotate(270deg);
-    }
-    50% {
-         transform:rotate(360deg);
-    }
-    100% {
-         transform:rotate(270deg);
-    }
+@keyframes rotate_pacman_half_up {
+  0% {
+    transform: rotate(270deg);
+  }
+  50% {
+    transform: rotate(360deg);
+  }
+  100% {
+    transform: rotate(270deg);
+  }
 }
 
-@keyframes rotate_pacman_half_down  {
-    0% {
-         transform:rotate(90deg);
-    }
-    50% {
-         transform:rotate(0deg);
-    }
-    100% {
-         transform:rotate(90deg);
-    }
+@keyframes rotate_pacman_half_down {
+  0% {
+    transform: rotate(90deg);
+  }
+  50% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(90deg);
+  }
 }
 
-@mixin pacman_design(){
-    width: 0px;
-    height: 0px;
-    border-right: $size solid transparent;
-    border-top: $size solid $primary-color;
-    border-left: $size solid $primary-color;
-    border-bottom: $size solid $primary-color;
-    border-radius: $size;
+@mixin pacman_design() {
+  width: 0px;
+  height: 0px;
+  border-right: $size solid transparent;
+  border-top: $size solid $primary-color;
+  border-left: $size solid $primary-color;
+  border-bottom: $size solid $primary-color;
+  border-radius: $size;
 }
 
 @keyframes pacman-balls {
@@ -43,14 +44,14 @@ $size: 25px;
     opacity: 0.7;
   }
   100% {
-    transform: translate(-4 * $size, -$size / 4);
+    transform: translate(-4 * $size, math.div(-$size, 4));
   }
 }
 
-@mixin ball-placement($n:3, $start:0) {
+@mixin ball-placement($n: 3, $start: 0) {
   @for $i from $start through $n {
     > div:nth-child(#{$i + 2}) {
-      animation: pacman-balls 1s delay(.33s, $n, $i) infinite linear;
+      animation: pacman-balls 1s delay(0.33s, $n, $i) infinite linear;
     }
   }
 }
@@ -85,7 +86,7 @@ $size: 25px;
     height: 10px;
 
     position: absolute;
-    transform: translate(0, -$size / 4);
+    transform: translate(0, math.div(-$size, 4));
     top: 25px;
     left: 70px;
   }


### PR DESCRIPTION
Replace / as division operation with the new math.div function in sass issue #102

reference from Sass: https://sass-lang.com/documentation/breaking-changes/slash-div

in src/animations/pacman.scss file lines 46 and 88 I use the new math.div function in sass to remove deprecation warning about the old slash operation for division

in src/animations/ball-scale-multiple.scss file line 33 I use the same math.div to resolve issue #102 
